### PR TITLE
DRUD-511: don't fail if no secret/validation/maps exists

### DIFF
--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -301,7 +301,9 @@ func (s *Secret) Validate() (bool, error) {
 	mapPath := filepath.Join("secret/validation/maps", sPath)
 	sMap, err := vault.Read(mapPath)
 	if err != nil {
-		return false, err
+		if !strings.Contains(err.Error(), "No secret") {
+			return false, err
+		}
 	}
 
 	// no validation


### PR DESCRIPTION
In a vault instance where there is no `secret/validation/maps` the cli tool will fail. This PR will allow the cli to pass that failure point and act as if there just were no applicable validation schemes.