### PR TITLE
Separating deploys from application entities

### DIFF
--- a/drudapi/applications.go
+++ b/drudapi/applications.go
@@ -57,38 +57,23 @@ func (l *LoginLink) Unmarshal(data []byte) error {
 	return err
 }
 
-// Deploy ...
-type Deploy struct {
-	Name          string `json:"name,omitempty"`
-	Template      string `json:"template,omitempty"`
-	Branch        string `json:"branch,omitempty"`
-	Hostname      string `json:"hostname,omitempty"`
-	Protocol      string `json:"protocol,omitempty"`
-	BasicAuthUser string `json:"basicauth_user,omitempty"`
-	BasicAuthPass string `json:"basicauth_pass,omitempty"`
-	AutoManaged   bool   `json:"auto_managed,omitempty"`
-	MigrateFrom   string `json:"migrate_from,omitempty"`
-	Url           string `json:"url,omitempty"`
-}
-
 // Application ...
 type Application struct {
-	AppID          string   `json:"app_id,omitempty"`
-	Client         Client   `json:"client,omitempty"`
-	Deploys        []Deploy `json:"deploys,omitempty"`
-	GithubHookID   int      `json:"github_hook_id,omitempty"`
-	RepoOrg        string   `json:"repo_org,omitempty"`
-	Name           string   `json:"name,omitempty"`
-	Repo           string   `json:"repo,omitempty"`
-	SlackChannel   string   `json:"slack_channel,omitempty"`
-	AuthKey        string   `json:"auth_key,omitempty"`
-	SecureAuthKey  string   `json:"secure_auth_key,omitempty"`
-	LoggedInKey    string   `json:"logged_in_key,omitempty"`
-	NonceKey       string   `json:"nonce_key,omitempty"`
-	AuthSalt       string   `json:"auth_salt,omitempty"`
-	SecureAuthSalt string   `json:"secure_auth_salt,omitempty"`
-	LoggedInSalt   string   `json:"logged_in_salt,omitempty"`
-	NonceSalt      string   `json:"nonce_salt,omitempty"`
+	AppID          string `json:"app_id,omitempty"`
+	Client         Client `json:"client,omitempty"`
+	GithubHookID   int    `json:"github_hook_id,omitempty"`
+	RepoOrg        string `json:"repo_org,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Repo           string `json:"repo,omitempty"`
+	SlackChannel   string `json:"slack_channel,omitempty"`
+	AuthKey        string `json:"auth_key,omitempty"`
+	SecureAuthKey  string `json:"secure_auth_key,omitempty"`
+	LoggedInKey    string `json:"logged_in_key,omitempty"`
+	NonceKey       string `json:"nonce_key,omitempty"`
+	AuthSalt       string `json:"auth_salt,omitempty"`
+	SecureAuthSalt string `json:"secure_auth_salt,omitempty"`
+	LoggedInSalt   string `json:"logged_in_salt,omitempty"`
+	NonceSalt      string `json:"nonce_salt,omitempty"`
 	RepoDetails    *struct {
 		Host     string `json:"host,omitempty"`
 		Name     string `json:"name,omitempty"`

--- a/drudapi/deploys.go
+++ b/drudapi/deploys.go
@@ -1,0 +1,131 @@
+package drudapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gosuri/uitable"
+)
+
+// Deploy ...
+type Deploy struct {
+	DeployID      string      `json:"deploy_id,omitempty"`
+	Name          string      `json:"name,omitempty"`
+	Application   Application `json:"application,omitempty"`
+	Template      string      `json:"template,omitempty"`
+	Branch        string      `json:"branch,omitempty"`
+	Hostname      string      `json:"hostname,omitempty"`
+	Protocol      string      `json:"protocol,omitempty"`
+	BasicAuthUser string      `json:"basicauth_user,omitempty"`
+	BasicAuthPass string      `json:"basicauth_pass,omitempty"`
+	AutoManaged   bool        `json:"auto_managed,omitempty"`
+	MigrateFrom   string      `json:"migrate_from,omitempty"`
+	Url           string      `json:"url,omitempty"`
+	Created       string      `json:"_created,omitempty"`
+	Etag          string      `json:"_etag,omitempty"`
+	ID            string      `json:"_id,omitempty"`
+	Updated       string      `json:"_updated,omitempty"`
+}
+
+// Path ...
+func (d Deploy) Path(method string) string {
+	var path string
+
+	if method == "POST" {
+		path = "deploys"
+	} else {
+		path = "dep[oys/" + d.DeployID
+	}
+	return path
+}
+
+// Unmarshal ...
+func (d *Deploy) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, d)
+	return err
+}
+
+// JSON ...
+func (d Deploy) JSON() []byte {
+	d.ID = ""
+	d.Etag = ""
+	d.Created = ""
+	d.Updated = ""
+
+	jbytes, _ := json.Marshal(d)
+	return jbytes
+}
+
+// PatchJSON ...
+func (d Deploy) PatchJSON() []byte {
+	d.ID = ""
+	d.Etag = ""
+	d.Created = ""
+	d.Updated = ""
+	// removing name because it has been setup as the id param in drudapi and cannot be  patched
+	d.DeployID = ""
+
+	jbytes, _ := json.Marshal(d)
+	return jbytes
+}
+
+// ETAG ...
+func (d Deploy) ETAG() string {
+	return d.Etag
+}
+
+// Describe an application..mostly used for displaying deploys
+func (d *Deploy) Describe() {
+
+	table := uitable.New()
+	table.MaxColWidth = 50
+	table.Wrap = true // wrap columns
+
+	table.AddRow("DEPLOY:", d.DeployID)
+	table.AddRow("APP:", d.Application.AppID)
+	table.AddRow("CLIENT:", d.Application.Client.Name)
+	table.AddRow("CREATED:", d.Created)
+
+	fmt.Println(table)
+
+}
+
+// DeployList entity
+type DeployList struct {
+	Name  string
+	Items []Deploy `json:"_items"`
+	Meta  struct {
+		MaxResults int `json:"max_results"`
+		Page       int `json:"page"`
+		Total      int `json:"total"`
+	} `json:"_meta"`
+}
+
+// Path ...
+func (d DeployList) Path(method string) string {
+	return "deploys"
+}
+
+// Unmarshal ...
+func (d *DeployList) Unmarshal(data []byte) error {
+	err := json.Unmarshal(data, &d)
+	return err
+}
+
+// Describe pretty prints the entity
+func (d *DeployList) Describe() {
+	fmt.Printf("%v %v found.\n\n", len(d.Items), FormatPlural(len(d.Items), "deploy", "deploys"))
+
+	table := uitable.New()
+	table.MaxColWidth = 50
+	table.AddRow("NAME", "CLIENT", "CREATED")
+	for _, deploy := range d.Items {
+		table.AddRow(
+			deploy.DeployID,
+			deploy.Application.Client.Name,
+			deploy.Created,
+		)
+	}
+	fmt.Println(table)
+
+}

--- a/drudapi/deploys.go
+++ b/drudapi/deploys.go
@@ -9,22 +9,30 @@ import (
 
 // Deploy ...
 type Deploy struct {
-	DeployID      string      `json:"deploy_id,omitempty"`
-	Name          string      `json:"name,omitempty"`
-	Application   Application `json:"application,omitempty"`
-	Template      string      `json:"template,omitempty"`
-	Branch        string      `json:"branch,omitempty"`
-	Hostname      string      `json:"hostname,omitempty"`
-	Protocol      string      `json:"protocol,omitempty"`
-	BasicAuthUser string      `json:"basicauth_user,omitempty"`
-	BasicAuthPass string      `json:"basicauth_pass,omitempty"`
-	AutoManaged   bool        `json:"auto_managed,omitempty"`
-	MigrateFrom   string      `json:"migrate_from,omitempty"`
-	Url           string      `json:"url,omitempty"`
-	Created       string      `json:"_created,omitempty"`
-	Etag          string      `json:"_etag,omitempty"`
-	ID            string      `json:"_id,omitempty"`
-	Updated       string      `json:"_updated,omitempty"`
+	DeployID       string      `json:"deploy_id,omitempty"`
+	Name           string      `json:"name,omitempty"`
+	Application    Application `json:"application,omitempty"`
+	Template       string      `json:"template,omitempty"`
+	Branch         string      `json:"branch,omitempty"`
+	Hostname       string      `json:"hostname,omitempty"`
+	Protocol       string      `json:"protocol,omitempty"`
+	BasicAuthUser  string      `json:"basicauth_user,omitempty"`
+	BasicAuthPass  string      `json:"basicauth_pass,omitempty"`
+	AutoManaged    bool        `json:"auto_managed,omitempty"`
+	MigrateFrom    string      `json:"migrate_from,omitempty"`
+	Url            string      `json:"url,omitempty"`
+	AuthKey        string      `json:"auth_key,omitempty"`
+	SecureAuthKey  string      `json:"secure_auth_key,omitempty"`
+	LoggedInKey    string      `json:"logged_in_key,omitempty"`
+	NonceKey       string      `json:"nonce_key,omitempty"`
+	AuthSalt       string      `json:"auth_salt,omitempty"`
+	SecureAuthSalt string      `json:"secure_auth_salt,omitempty"`
+	LoggedInSalt   string      `json:"logged_in_salt,omitempty"`
+	NonceSalt      string      `json:"nonce_salt,omitempty"`
+	Created        string      `json:"_created,omitempty"`
+	Etag           string      `json:"_etag,omitempty"`
+	ID             string      `json:"_id,omitempty"`
+	Updated        string      `json:"_updated,omitempty"`
 }
 
 // Path ...

--- a/drudapi/deploys.go
+++ b/drudapi/deploys.go
@@ -34,7 +34,7 @@ func (d Deploy) Path(method string) string {
 	if method == "POST" {
 		path = "deploys"
 	} else {
-		path = "dep[oys/" + d.DeployID
+		path = "deploys/" + d.DeployID
 	}
 	return path
 }
@@ -120,11 +120,16 @@ func (d *DeployList) Describe() {
 	table.MaxColWidth = 50
 	table.AddRow("NAME", "CLIENT", "CREATED")
 	for _, deploy := range d.Items {
-		table.AddRow(
-			deploy.DeployID,
-			deploy.Application.Client.Name,
-			deploy.Created,
-		)
+		table.AddRow("DEPLOY ID:", deploy.DeployID)
+		table.AddRow("NAME:", deploy.Name)
+		table.AddRow("URL:", deploy.Url)
+		table.AddRow("TEMPLATE:", deploy.Template)
+		table.AddRow("BRANCH:", deploy.Branch)
+		table.AddRow("AUTH USER:", deploy.BasicAuthUser)
+		table.AddRow("AUTH PASS:", deploy.BasicAuthPass)
+		table.AddRow("AUTO MANAGED:", deploy.AutoManaged)
+		table.AddRow("\n")
+
 	}
 	fmt.Println(table)
 


### PR DESCRIPTION
## The Problem:
Deploys in Drud API will now be separate entities from the applications they belong to. The tools
working with the API will need to change accordingly.

## The Fix:

- [x] - reorg deploys into their own file
- [x] - update application.go methods that work with deploys to source their data from the /deploys endpoint
- [x] - update drud cli to post a new default deploy after the creation of a new application

## The Test:
- build a binary for drud cli that uses the updated drudapi lib
- create an app like you normally would
- curl https://drudapi.your.cluster/deploys and ensure the new deploy associated with your app is there
- ensure the app deployed and is accessible via the web

## Related Issue Link(s):
drud/general#36

## Release/Deployment notes:
There may be a microservice or two implementing this lib as well that need to be updated

