### PR TITLE
updates pkg name for docker util pkg

### DIFF
--- a/utils/docker/docker.go
+++ b/utils/docker/docker.go
@@ -1,4 +1,4 @@
-package utils
+package docker
 
 import (
 	"bytes"


### PR DESCRIPTION
## The Problem:
This package definition for docker was not renamed so it does not show up as its own package.
## The Fix:
This one-liner that you should merge.
## The Test:
Look at the one line change with your eyes and merge it.
## Related Issue Link(s):

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?
This needs to be done before other projects referencing this package can be updated.
